### PR TITLE
Allow reusing validators

### DIFF
--- a/src/Validate.elm
+++ b/src/Validate.elm
@@ -16,6 +16,7 @@ module Validate
         , isBlank
         , isInt
         , isValidEmail
+        , preMap
         , validate
         )
 
@@ -55,6 +56,11 @@ module Validate
 # Combining validators
 
 @docs all, any, firstError
+
+
+# Reusing validators
+
+@docs preMap
 
 
 # Checking values directly
@@ -217,6 +223,33 @@ ifFalse test error =
                 [ error ]
     in
     Validator getErrors
+
+
+
+-- REUSING VALIDATORS --
+
+
+{-| Reuse a validator in a larger context.
+
+    import Validate exposing (ifBlank, preMap)
+
+    type alias User =
+        { name : String
+        }
+
+    nameValidator : Validator String String
+    nameValidator =
+        ifBlank identity
+            "Please enter a name"
+
+    userValidator : Validator String User
+    userValidator =
+        preMap .user nameValidator
+
+-}
+preMap : (large -> small) -> Validator error small -> Validator error large
+preMap f (Validator validator) =
+    Validator (f >> validator)
 
 
 


### PR DESCRIPTION
Some sort of contravariant map would allow reusing validators in different
contexts.

Possible names, with input from @norpan and @gyzerok on slack:
- [`preMap`](http://klaftertief.github.io/elm-search/?q=preMap)
- [`comap`](http://klaftertief.github.io/elm-search/?q=comap)
- `contraMap` (not used in Elm, so far)
- `select` (i.e. `Validate.select .name nameValidator`)

I sort of like `select`, though I'd already typed it out with `preMap` and figured a PR was a better place for discussion.

One alternative is to encourage users to write `Sometype -> Validator Error Sometype` style functions instead. I feel like that sort of defeats the purpose of providing a nice type for a validator, though.