### PR TITLE
Correcting README.md documentation where Validator constructor has inverted params

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ type alias Model =
     { name : String, email : String, age : String, selections : List String }
 
 
-modelValidator : Validator Model String
+modelValidator : Validator String Model
 modelValidator =
     Validate.all
         [ ifBlank .name "Please enter a name."


### PR DESCRIPTION
The Validator type is defined this way:

```
type Validator error subject
    = Validator (subject -> List error)
```

The error and the subject are swapped in the README.md file.