### PR TITLE
Updates to docs to reflect new use of Result

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ validation failed.
 
 ```elm
 case validate someValidator someSubject of
-  Result.Ok validSubject -> ...--> (Valid someSubject)
-  Result.Err validationErrors -> ...--> List of validation errors
+  Ok validSubject -> ...--> (Valid someSubject)
+  Err validationErrors -> ...--> List of validation errors
 ```
 
 For example:
@@ -35,11 +35,11 @@ modelValidator =
 
 validate modelValidator
     { name = "Sam", email = "", age = "abc", selections = [ "cats" ] }
-    --> Result.Err [ "Please enter an email address.", "Age must be a whole number." ]
+    --> Err [ "Please enter an email address.", "Age must be a whole number." ]
 
 validate modelValidator
     { name = "Sam", email = "sam@samtown.com", age = "27", selections = [ "cats" ] }
-    --> Result.Ok (Valid { name = "Sam", email = "sam@samtown.com", age = "27", selections = [ "cats" ] })
+    --> Ok (Valid { name = "Sam", email = "sam@samtown.com", age = "27", selections = [ "cats" ] })
 
 ```
 
@@ -67,7 +67,7 @@ type alias Model =
 
 validate modelValidator
     { name = "Sam", email = "", age = "abc", selections = [ "cats" ] }
-    --> Result.Err [ ( Email, "Please enter an email address." )
+    --> Err [ ( Email, "Please enter an email address." )
     -->   , ( Age, "Age must be a whole number." )
     -->   ]
 ```

--- a/README.md
+++ b/README.md
@@ -3,8 +3,15 @@
 `elm-validate` provides convenience functions for validating data.
 
 It is based around the idea of a `Validator`, which runs checks on a
-subject and returns a list of errors representing anything invalid about
-that subject. If the list is empty, the subject is valid.
+subject and returns a `Result` which can be be either `Ok (Valid originalSubject)`
+if there were no validation errors or `Err validationErrors` if the
+validation failed.
+
+```elm
+case validate someValidator someSubject of
+  Result.Ok validSubject -> ...--> (Valid someSubject)
+  Result.Err validationErrors -> ...--> List of validation errors
+```
 
 For example:
 
@@ -28,7 +35,12 @@ modelValidator =
 
 validate modelValidator
     { name = "Sam", email = "", age = "abc", selections = [ "cats" ] }
-    --> [ "Please enter an email address.", "Age must be a whole number." ]
+    --> Result.Err [ "Please enter an email address.", "Age must be a whole number." ]
+
+validate modelValidator
+    { name = "Sam", email = "sam@samtown.com", age = "27", selections = [ "cats" ] }
+    --> Result.Ok (Valid { name = "Sam", email = "sam@samtown.com", age = "27", selections = [ "cats" ] })
+
 ```
 
 You can represent your errors however you like. One nice approach is to use
@@ -55,9 +67,9 @@ type alias Model =
 
 validate modelValidator
     { name = "Sam", email = "", age = "abc", selections = [ "cats" ] }
-    --> [ ( Email, "Please enter an email address." )
-    --> , ( Age, "Age must be a whole number." )
-    --> ]
+    --> Result.Err [ ( Email, "Please enter an email address." )
+    -->   , ( Age, "Age must be a whole number." )
+    -->   ]
 ```
 
 Functions that detect the _absence_ of a value, such as `ifBlank` and `ifEmptyList`, accept an error as the second argument:

--- a/src/Validate.elm
+++ b/src/Validate.elm
@@ -25,7 +25,7 @@ module Validate exposing
             ]
 
     validate modelValidator { name = "Sam", email = "blah", age = "abc" }
-        --> [ "This is not a valid email address.", "Age must be a whole number." ]
+        --> Result.Err [ "This is not a valid email address.", "Age must be a whole number." ]
 
 
 # Validating a subject
@@ -113,7 +113,7 @@ subject.
             ]
 
     validate modelValidator { name = "Sam", email = "", age = "abc" }
-        --> [ ( Email, "Please enter an email address." ), ( Age, "Age must be a whole number." ) ]
+        --> Result.Err [ ( Email, "Please enter an email address." ), ( Age, "Age must be a whole number." ) ]
 
 -}
 validate : Validator error subject -> subject -> Result (List error) (Valid subject)
@@ -372,13 +372,13 @@ and returning it. If no errors are encountered, return `Nothing`.
 
 
     validate modelValidator { email = " ", age = "5" }
-        --> [ "Please enter an email address." ]
+        --> Result.Err [ "Please enter an email address." ]
 
     validate modelValidator { email = "blah", age = "5" }
-        --> [ "This is not a valid email address." ]
+        --> Result.Err [ "This is not a valid email address." ]
 
     validate modelValidator { email = "foo@bar.com", age = "5" }
-        --> []
+        --> Result.Ok (Valid { email = "foo@bar.com", age = "5" })
 
 -}
 firstError : List (Validator error subject) -> Validator error subject

--- a/src/Validate.elm
+++ b/src/Validate.elm
@@ -25,7 +25,7 @@ module Validate exposing
             ]
 
     validate modelValidator { name = "Sam", email = "blah", age = "abc" }
-        --> Result.Err [ "This is not a valid email address.", "Age must be a whole number." ]
+        --> Err [ "This is not a valid email address.", "Age must be a whole number." ]
 
 
 # Validating a subject
@@ -113,7 +113,7 @@ subject.
             ]
 
     validate modelValidator { name = "Sam", email = "", age = "abc" }
-        --> Result.Err [ ( Email, "Please enter an email address." ), ( Age, "Age must be a whole number." ) ]
+        --> Err [ ( Email, "Please enter an email address." ), ( Age, "Age must be a whole number." ) ]
 
 -}
 validate : Validator error subject -> subject -> Result (List error) (Valid subject)
@@ -372,13 +372,13 @@ and returning it. If no errors are encountered, return `Nothing`.
 
 
     validate modelValidator { email = " ", age = "5" }
-        --> Result.Err [ "Please enter an email address." ]
+        --> Err [ "Please enter an email address." ]
 
     validate modelValidator { email = "blah", age = "5" }
-        --> Result.Err [ "This is not a valid email address." ]
+        --> Err [ "This is not a valid email address." ]
 
     validate modelValidator { email = "foo@bar.com", age = "5" }
-        --> Result.Ok (Valid { email = "foo@bar.com", age = "5" })
+        --> Ok (Valid { email = "foo@bar.com", age = "5" })
 
 -}
 firstError : List (Validator error subject) -> Validator error subject


### PR DESCRIPTION
A few tweaks to README / comments to update them to reflect the new `Result` return from `validate`.

Previously this would just return a list of validation errors but this is now wrapped in `Result` and (if valid) `Valid`