### PR TITLE
correcting documentation for validators that return a context

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ case validate someValidator someSubject of
 For example:
 
 ```elm
-import Validate exposing (ifBlank, ifNotInt, validate)
+import Validate exposing (ifBlank, ifNotInt, ifEmptyList, validate)
 
 
 type alias Model =
@@ -28,7 +28,7 @@ modelValidator =
     Validate.all
         [ ifBlank .name "Please enter a name."
         , ifBlank .email "Please enter an email address."
-        , ifNotInt .age "Age must be a whole number."
+        , ifNotInt .age (\_ -> ("Age must be a whole number."))
         , ifEmptyList .selections "Please select at least one."
         ]
 
@@ -56,7 +56,7 @@ modelValidator =
     Validate.all
         [ ifBlank .name ( Name, "Please enter a name." )
         , ifBlank .email ( Email, "Please enter an email address." )
-        , ifNotInt .age ( Age, "Age must be a whole number." )
+        , ifNotInt .age (\value -> ( Age, value ++ "is not a whole number." ))
         , ifEmptyList .selections ( Selections, "Please select at least one." )
         ]
 

--- a/examples/SignupForm.elm
+++ b/examples/SignupForm.elm
@@ -20,9 +20,9 @@ modelValidator =
         [ ifBlank .name ( Name, "Please enter a name." )
         , Validate.firstError
             [ ifBlank .email ( Email, "Please enter an email address." )
-            , ifInvalidEmail .email ( Email, "This is not a valid email address." )
+            , ifInvalidEmail .email (\value -> ( Email, value ++ " is not a valid email address." ))
             ]
-        , ifNotInt .age ( Age, "Age must be a whole number." )
+        , ifNotInt .age (\_ -> ( Age, "Age must be a whole number." ))
         , ifEmptyList .selections ( Selections, "Please select at least one." )
         ]
 

--- a/src/Validate.elm
+++ b/src/Validate.elm
@@ -21,7 +21,7 @@ module Validate exposing
                 [ ifBlank .email "Please enter an email address."
                 , ifInvalidEmail .email "This is not a valid email address."
                 ]
-            , ifNotInt .age "Age must be a whole number."
+            , ifNotInt .age (\_ -> "Age must be a whole number.")
             ]
 
     validate modelValidator { name = "Sam", email = "blah", age = "abc" }
@@ -109,7 +109,7 @@ subject.
         Validate.all
             [ ifBlank .name ( Name, "Please enter a name." )
             , ifBlank .email ( Email, "Please enter an email address." )
-            , ifNotInt .age ( Age, "Age must be a whole number." )
+            , ifNotInt .age (\_ -> ( Age, "Age must be a whole number." ))
             ]
 
     validate modelValidator { name = "Sam", email = "", age = "abc" }
@@ -333,7 +333,7 @@ error lists.
         Validate.all
             [ ifBlank .name "Please enter a name."
             , ifBlank .email "Please enter an email address."
-            , ifNotInt .age "Age must be a whole number."
+            , ifNotInt .age (\_ -> "Age must be a whole number.")
             ]
 
 -}
@@ -364,10 +364,10 @@ and returning it. If no errors are encountered, return `Nothing`.
     modelValidator =
         Validate.all
             [ Validate.firstError
-                [ ifBlank .email "Please enter an email address."
-                , ifInvalidEmail .email "This is not a valid email address."
+                [ ifBlank .email (\_ -> "Please enter an email address.")
+                , ifInvalidEmail .email (\_ -> "This is not a valid email address.")
                 ]
-            , ifNotInt .age "Age must be a whole number."
+            , ifNotInt .age (\_ -> "Age must be a whole number.")
             ]
 
 


### PR DESCRIPTION
I've corrected the documentation for validator functions that return a context (`ifNotInt` and `ifInvalidEmail`).

This change was implemented in version 3.0.0

[Issue 32](https://github.com/rtfeldman/elm-validate/issues/32)
